### PR TITLE
Fix a problem that prevents updates from clients from being saved

### DIFF
--- a/Assets/Voxelmetric/Code/World/VmServer.cs
+++ b/Assets/Voxelmetric/Code/World/VmServer.cs
@@ -218,7 +218,7 @@ public class VmServer {
 
     public void ReceiveChange(BlockPos pos, Block block, int id)
     {
-        world.blocks.Set(pos, block, updateChunk: true, setBlockModified: false);
+        world.blocks.Set(pos, block, updateChunk: true, setBlockModified: true);
         BroadcastChange(pos, block, id);
     }
 }


### PR DESCRIPTION
When a client attached to the server and made changes to the world those changes were not saved when the world was saved.
This patch fixes that.