### PR TITLE
Improve performance of usage of BlockPos as a Dictionary key

### DIFF
--- a/Assets/Voxelmetric/Code/Data types/BlockPos.cs
+++ b/Assets/Voxelmetric/Code/Data types/BlockPos.cs
@@ -2,7 +2,7 @@
 using System;
 
 [Serializable]
-public struct BlockPos
+public struct BlockPos : IEquatable<BlockPos>
 {
     public int x, y, z;
 
@@ -54,19 +54,34 @@ public struct BlockPos
 
     public override bool Equals(object obj)
     {
-        if (GetHashCode() == obj.GetHashCode())
-            return true;
-
-        return false;
+        if (!(obj is BlockPos))
+            return false;
+        BlockPos other = (BlockPos)obj;
+        return Equals(other);
     }
 
-    //returns the position of the chunk containing this block
-    public BlockPos ContainingChunkCoordinates() {
-        int x = Mathf.FloorToInt(this.x / (float)Config.Env.ChunkSize) * Config.Env.ChunkSize;
-        int y = Mathf.FloorToInt(this.y / (float)Config.Env.ChunkSize) * Config.Env.ChunkSize;
-        int z = Mathf.FloorToInt(this.z / (float)Config.Env.ChunkSize) * Config.Env.ChunkSize;
+    public bool Equals(BlockPos other) {
+        if (GetHashCode() != other.GetHashCode())
+            return false;
+        if (x != other.x)
+            return false;
+        if (y != other.y)
+            return false;
+        if (z != other.z)
+            return false;
+        return true;
+    }
 
-        return new BlockPos(x, y, z);
+    /// <summary>
+    /// returns the position of the chunk containing this block
+    /// </summary>
+    /// <returns>the position of the chunk containing this block</returns>
+    public BlockPos ContainingChunkCoordinates() {
+        const int chunkPower = Config.Env.ChunkPower;
+        return new BlockPos(
+            (x >> chunkPower) << chunkPower,
+            (y >> chunkPower) << chunkPower,
+            (z >> chunkPower) << chunkPower);
     }
 
     public BlockPos Add(int x, int y, int z)
@@ -82,6 +97,11 @@ public struct BlockPos
     public BlockPos Subtract(BlockPos pos)
     {
         return new BlockPos(x - pos.x, y - pos.y, z - pos.z);
+    }
+
+    public BlockPos Negate()
+    {
+        return new BlockPos(-x, -y, -z);
     }
 
     public byte[] ToBytes()
@@ -148,6 +168,10 @@ public struct BlockPos
         return pos1.Subtract(pos2);
     }
 
+    public static BlockPos operator -(BlockPos pos) {
+        return pos.Negate();
+    }
+
     public static bool operator >(BlockPos pos1, BlockPos pos2)
     {
         return (pos1.x > pos2.x || pos1.y > pos2.y || pos1.z > pos2.x);
@@ -185,12 +209,12 @@ public struct BlockPos
 
     public static bool operator ==(BlockPos pos1, BlockPos pos2)
     {
-        return Equals(pos1, pos2);
+        return pos1.Equals(pos2);
     }
 
     public static bool operator !=(BlockPos pos1, BlockPos pos2)
     {
-        return !Equals(pos1, pos2);
+        return !pos1.Equals(pos2);
     }
 
     //You can safely use BlockPos as part of a string like this:
@@ -202,4 +226,13 @@ public struct BlockPos
 
     // first 255 prime numbers and 1. Used for randomizing a number in the RandomPercent function.
     static readonly int[] primeNumbers = new int[]{1, 2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317, 331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541, 547, 557, 563, 569, 571, 577, 587, 593, 599, 601, 607, 613, 617, 619, 631, 641, 643, 647, 653, 659, 661, 673, 677, 683, 691, 701, 709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787, 797, 809, 811, 821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911, 919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997, 1009, 1013, 1019, 1021, 1031, 1033, 1039, 1049, 1051, 1061, 1063, 1069, 1087, 1091, 1093, 1097, 1103, 1109, 1117, 1123, 1129, 1151, 1153, 1163, 1171, 1181, 1187, 1193, 1201, 1213, 1217, 1223, 1229, 1231, 1237, 1249, 1259, 1277, 1279, 1283, 1289, 1291, 1297, 1301, 1303, 1307, 1319, 1321, 1327, 1361, 1367, 1373, 1381, 1399, 1409, 1423, 1427, 1429, 1433, 1439, 1447, 1451, 1453, 1459, 1471, 1481, 1483, 1487, 1489, 1493, 1499, 1511, 1523, 1531, 1543, 1549, 1553, 1559, 1567, 1571, 1579, 1583, 1597, 1601, 1607, 1609, 1613, 1619};
+
+    //
+    // Summary:
+    //     Shorthand for writing BlockPos(0, 0, 0).
+    public static readonly BlockPos zero = new BlockPos(0, 0, 0);
+    //
+    // Summary:
+    //     Shorthand for writing BlockPos(1, 1, 1).
+    public static readonly BlockPos one = new BlockPos(1, 1, 1);
 }

--- a/Assets/Voxelmetric/Code/Utilities/BlockPosEnumerable.cs
+++ b/Assets/Voxelmetric/Code/Utilities/BlockPosEnumerable.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+public class BlockPosEnumerable : IEnumerable<BlockPos> {
+
+    private readonly BlockPos start;
+    private readonly BlockPos end;
+    private readonly BlockPos step;
+    private readonly bool includesEnd;
+
+    public BlockPosEnumerable(BlockPos end, bool includesEnd = false) :
+            this(BlockPos.zero, end, includesEnd) {
+    }
+
+    public BlockPosEnumerable(BlockPos start, BlockPos end, bool includesEnd = false) :
+            this(start, end, BlockPos.one, includesEnd) {
+    }
+
+    public BlockPosEnumerable(BlockPos start, BlockPos end, BlockPos step, bool includesEnd = false) {
+        this.start = start;
+        this.end = end;
+        this.step = step;
+        if (includesEnd)
+            this.end += step;
+    }
+
+    public IEnumerator<BlockPos> GetEnumerator() {
+        for (int x = start.x; x < end.x; x += step.x) {
+            for (int y = start.y; y < end.y; y += step.y) {
+                for (int z = start.z; z < end.z; z += step.z) {
+                    yield return new BlockPos(x, y, z);
+                }
+            }
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() {
+        return GetEnumerator();
+    }
+}

--- a/Assets/Voxelmetric/Code/Utilities/BlockPosEnumerable.cs.meta
+++ b/Assets/Voxelmetric/Code/Utilities/BlockPosEnumerable.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c05a0e868cc446241b6feebae3e77567
+timeCreated: 1459736824
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Voxelmetric/Code/Utilities/Config.cs
+++ b/Assets/Voxelmetric/Code/Utilities/Config.cs
@@ -4,8 +4,9 @@ namespace Config
 {
     public static class Env
     {
-        public static int ChunkSize = 16;
-        public static float BlockSize = 1f;
+        public const int ChunkPower = 4;
+        public const int ChunkSize = 1 << 4;
+        public const float BlockSize = 1f;
 
         // Padding added to the size of block faces to fix floating point issues 
         // where tiny gaps can appear between block faces

--- a/Assets/Voxelmetric/Code/VoxelmetricResources.cs
+++ b/Assets/Voxelmetric/Code/VoxelmetricResources.cs
@@ -67,7 +67,7 @@ public class VoxelmetricResources {
         }
 
         blockIndex = new BlockIndex(world.config.blockFolder, world);
-        blockIndexes.Add(world.config.textureFolder, blockIndex);
+        blockIndexes.Add(world.config.blockFolder, blockIndex);
         return blockIndex;
     }
 

--- a/Assets/Voxelmetric/Code/World/VmClient.cs
+++ b/Assets/Voxelmetric/Code/World/VmClient.cs
@@ -2,36 +2,58 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
+using System.Runtime.CompilerServices;
 
-public class VmClient
+public class VmClient : VmSocketState.IMessageHandler
 {
     protected World world;
-    int id;
+    private IPAddress serverIP;
     private Socket clientSocket;
-    private byte[] buffer = new byte[VmNetworking.bufferLength];
 
     public bool connected;
 
-    public VmClient(World world)
+    private bool debugClient = false;
+
+    public IPAddress ServerIP { get { return serverIP; } }
+
+    public VmClient(World world, IPAddress serverIP = null)
     {
         this.world = world;
+        this.serverIP = serverIP;
         ConnectToServer();
     }
 
     private void ConnectToServer()
     {
         clientSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-        clientSocket.BeginConnect(new IPEndPoint(Dns.GetHostAddresses(Dns.GetHostName())[0], 8000),
-            new AsyncCallback(OnConnect), null);
+
+        if (serverIP == null) {
+            string serverName = Dns.GetHostName();
+            Debug.Log("serverName='" + serverName + "'");
+            IPAddress serverAddress = Dns.GetHostAddresses(serverName)[0];
+            Debug.Log("serverAddress='" + serverAddress + "'");
+            serverIP = serverAddress;
+        }
+        IPEndPoint serverEndPoint = new IPEndPoint(serverIP, 8000);
+
+        clientSocket.BeginConnect(serverEndPoint, new AsyncCallback(OnConnect), null);
     }
     
     private void OnConnect(IAsyncResult ar)
     {
-        try
-        {
+        try {
+
+            if (clientSocket == null || !clientSocket.Connected) {
+                Debug.Log("VmClient.OnConnect (" + Thread.CurrentThread.ManagedThreadId + "): "
+                    + "server connection rejected because connection was shutdown or not started");
+                return;
+            }
             clientSocket.EndConnect(ar);
             connected = true;
-            clientSocket.BeginReceive(buffer, 0, VmNetworking.bufferLength, SocketFlags.None, new AsyncCallback(OnReceiveFromServer), null);
+
+            VmSocketState socketState = new VmSocketState(this);
+            clientSocket.BeginReceive(socketState.buffer, 0, VmNetworking.bufferLength, SocketFlags.None, new AsyncCallback(OnReceiveFromServer), socketState);
         }
         catch (Exception ex)
         {
@@ -43,19 +65,28 @@ public class VmClient
     {
         try
         {
+            if (clientSocket == null || !clientSocket.Connected) {
+                Debug.Log("VmClient.OnReceiveFromServer (" + Thread.CurrentThread.ManagedThreadId + "): "
+                    + "server message rejected because connection was shutdown or not started");
+                return;
+            }
             int received = clientSocket.EndReceive(ar);
 
             if (received == 0)
             {
                 Debug.Log("disconnected from server");
-                clientSocket.Close();
-                connected = false;
+                Disconnect();
                 return;
             }
 
-            RouteMessageToFunction(buffer);
+            if ( debugClient )
+                Debug.Log("VmClient.OnReceiveFromServer (" + Thread.CurrentThread.ManagedThreadId + "): ");
 
-            clientSocket.BeginReceive(buffer, 0, VmNetworking.bufferLength, SocketFlags.None, new AsyncCallback(OnReceiveFromServer), null);
+            VmSocketState socketState = ar.AsyncState as VmSocketState;
+            socketState.Receive(received, 0);
+            if (clientSocket != null && clientSocket.Connected) { // Should be able to use a mutex but unity doesn't seem to like it
+                clientSocket.BeginReceive(socketState.buffer, 0, VmNetworking.bufferLength, SocketFlags.None, new AsyncCallback(OnReceiveFromServer), socketState);
+            }
         }
         catch (Exception ex)
         {
@@ -63,8 +94,11 @@ public class VmClient
         }
     }
 
-    public void Send(byte[] buffer)
+    private void Send(byte[] buffer)
     {
+        if (!connected) {
+            return;
+        }
         try
         {
             clientSocket.BeginSend(buffer, 0, buffer.Length, SocketFlags.None, new AsyncCallback(OnSend), null);
@@ -80,55 +114,67 @@ public class VmClient
         try
         {
             clientSocket.EndSend(ar);
-        }
-        catch (Exception ex) 
+            if ( debugClient )
+                Debug.Log("VmClient.OnSend (" + Thread.CurrentThread.ManagedThreadId + "): send ended");
+        } catch (Exception ex) 
         {
             Debug.LogError(ex);
-            connected = false;
-            clientSocket.Close();
+            Disconnect();
         }
     }
 
-    public virtual void RouteMessageToFunction(byte[] receivedData)
-    {
+    public int GetExpectedSize(byte messageType) {
+        switch (messageType) {
+            case VmNetworking.SendBlockChange:
+                return 15;
+            case VmNetworking.transmitChunkData:
+                //TODO TCD So that small chunks don't need 1025 bytes to be sent...
+                //return -VmServer.leaderSize;
+                return VmNetworking.bufferLength;
+            default:
+                return 0;
+        }
+    }
 
+    public void HandleMessage(byte[] receivedData) {
         switch (receivedData[0]) {
             case VmNetworking.SendBlockChange:
                 BlockPos pos = BlockPos.FromBytes(receivedData, 1);
-                ReceiveChange(pos, Block.New(BitConverter.ToUInt16(receivedData, 13), world));
+                ushort type = BitConverter.ToUInt16(receivedData, 13);
+                ReceiveChange(pos, Block.New(type, world));
                 break;
             case VmNetworking.transmitChunkData:
-                ReceiveChunk(buffer);
+                ReceiveChunk(receivedData);
                 break;
-        }
-    }
-
-    internal void Disconnect()
-    {
-        if (clientSocket != null && clientSocket.Connected)
-        {
-            clientSocket.Shutdown(SocketShutdown.Both);
-            clientSocket.Close();
         }
     }
 
     public void RequestChunk(BlockPos pos)
     {
+        if ( debugClient )
+            Debug.Log("VmClient.RequestChunk (" + Thread.CurrentThread.ManagedThreadId + "): " + pos);
+
         byte[] message = new byte[13];
         message[0] = VmNetworking.RequestChunkData;
         pos.ToBytes().CopyTo(message, 1);
         Send(message);
     }
 
-    public void ReceiveChunk(byte[] data)
+    private void ReceiveChunk(byte[] data)
     {
         BlockPos pos = BlockPos.FromBytes(data, 1);
-        world.chunks.Get(pos).blocks.ReceiveChunkData(data);
+        Chunk chunk = world.chunks.Get(pos);
+        // for now just issue an error if it isn't yet loaded
+        if (chunk == null) {
+            Debug.LogError("VmClient.ReceiveChunk (" + Thread.CurrentThread.ManagedThreadId + "): "
+                + "Could not find chunk for " + pos);
+        } else
+            chunk.blocks.ReceiveChunkData(data);
     }
 
     public void BroadcastChange(BlockPos pos, Block block)
     {
-        byte[] data = new byte[15];
+        byte[] data = new byte[GetExpectedSize(VmNetworking.SendBlockChange)];
 
         data[0] = VmNetworking.SendBlockChange;
         pos.ToBytes().CopyTo(data, 1);
@@ -137,8 +183,19 @@ public class VmClient
         Send(data);
     }
 
-    public void ReceiveChange(BlockPos pos, Block block)
+    private void ReceiveChange(BlockPos pos, Block block)
     {
         world.blocks.Set(pos, block, updateChunk: true, setBlockModified: false);
     }
+
+    public void Disconnect() {
+        if (clientSocket != null)// && clientSocket.Connected)
+        {
+            //clientSocket.Shutdown(SocketShutdown.Both);
+            clientSocket.Close();
+            connected = false;
+            clientSocket = null;
+        }
+    }
+
 }

--- a/Assets/Voxelmetric/Code/World/VmNetworking.cs
+++ b/Assets/Voxelmetric/Code/World/VmNetworking.cs
@@ -10,7 +10,7 @@ public class VmNetworking {
     public VmServer server;
 
     //public string serverIPAdress;
-    //public IPAddress serverIP;
+    public IPAddress serverIP;
     //public int serverPort = 11000;
 
     public const int bufferLength = 1024;
@@ -40,12 +40,22 @@ public class VmNetworking {
             //    ipComponents[i] = byte.Parse(ipSplit[i]);
             //}
             //serverIP = new IPAddress(ipComponents);
-            client = new VmClient(world);
+            client = new VmClient(world, serverIP);
         }
         else if (allowConnections)
         {
             server = new VmServer(world);
         }
     }
-    
+
+    public void EndConnections() {
+        if (client != null) {
+            client.Disconnect();
+            client = null;
+        }
+        if (server != null) {
+            server.Disconnect();
+            server = null;
+        }
+    }
 }

--- a/Assets/Voxelmetric/Code/World/VmServer.cs
+++ b/Assets/Voxelmetric/Code/World/VmServer.cs
@@ -7,14 +7,28 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Linq;
 
 public class VmServer {
 
     protected World world;
+    private IPAddress serverIP;
     private Socket serverSocket;
-    private Dictionary<int, ClientConnection> clients = new Dictionary<int, ClientConnection>();
 
-    int nextId = 0;
+    private Dictionary<int, ClientConnection> clients = new Dictionary<int, ClientConnection>();
+    private int nextId = 0;
+
+    private bool debugServer = false;
+
+    public IPAddress ServerIP { get { return serverIP; } }
+
+    public int ClientCount {
+        get {
+            lock (clients) {
+                return clients.Count;
+            }
+        }
+    }
 
     public VmServer(World world)
     {
@@ -22,9 +36,20 @@ public class VmServer {
 
         try
         {
-            serverSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            AddressFamily addressFamily = AddressFamily.InterNetwork;
+            serverSocket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp);
 
-            serverSocket.Bind(new IPEndPoint(Dns.GetHostAddresses(Dns.GetHostName())[0], 8000));
+            string serverName = Dns.GetHostName();
+            if (debugServer) Debug.Log("serverName='" + serverName + "'");
+            foreach (IPAddress serverAddress in Dns.GetHostAddresses(serverName)) {
+                if (debugServer) Debug.Log("serverAddress='" + serverAddress + "', AddressFamily=" + serverAddress.AddressFamily);
+                if (serverAddress.AddressFamily !=  addressFamily)
+                    continue;
+                serverIP = serverAddress;
+                break;
+            }
+            IPEndPoint serverEndPoint = new IPEndPoint(serverIP, 8000);
+            serverSocket.Bind(serverEndPoint);
             serverSocket.Listen(0);
             serverSocket.BeginAccept(new AsyncCallback(OnJoinServer), null);
         }
@@ -38,10 +63,17 @@ public class VmServer {
     {
         try
         {
+            if (serverSocket == null) {
+                Debug.Log("VmServer.OnJoinServer (" + Thread.CurrentThread.ManagedThreadId + "): "
+                    + "client connection rejected because server was not started");
+                return;
+            }
             Socket newClientSocket = serverSocket.EndAccept(ar);
-            ClientConnection connection = new ClientConnection(clients.Count, newClientSocket, this);
-            clients.Add(nextId, connection);
-            nextId++;
+            lock(clients) {
+                ClientConnection connection = new ClientConnection(clients.Count, newClientSocket, this);
+                clients.Add(nextId, connection);
+                nextId++;
+            }
 
             serverSocket.BeginAccept(new AsyncCallback(OnJoinServer), null);
         }
@@ -51,141 +83,82 @@ public class VmServer {
         }
     }
 
-    private class ClientConnection
-    {
-        byte[] buffer = new byte[VmNetworking.bufferLength];
-        public int id;
-        Socket socket;
-        VmServer server;
-
-        public ClientConnection(int id, Socket socket, VmServer server)
-        {
-            this.id = id;
-            this.socket = socket;
-            this.server = server;
-            Debug.Log("Client " + id + " has connected");
-
-            socket.BeginReceive(buffer, 0, VmNetworking.bufferLength, SocketFlags.None, new AsyncCallback(OnReceiveFromClient), null);
-        }
-
-        private void OnReceiveFromClient(IAsyncResult ar)
-        {
-            try
-            {
-                int received = socket.EndReceive(ar);
-
-                if (received == 0)
-                {
-                    Disconnect();
-                    return;
-                }
-
-                server.RouteMessageToFunction(buffer, id);
-
-                socket.BeginReceive(buffer, 0, VmNetworking.bufferLength, SocketFlags.None, new AsyncCallback(OnReceiveFromClient), null);
-            }
-            catch (Exception ex)
-            {
-                Debug.LogError(ex);
-            }
-        }
-
-        public void Send(byte[] buffer)
-        {
-            try
-            {
-                socket.BeginSend(buffer, 0, buffer.Length, SocketFlags.None, new AsyncCallback(OnSend), null);
-            }
-            catch (Exception ex)
-            {
-                Debug.LogError(ex);
-            }
-        }
-
-        private void OnSend(IAsyncResult ar)
-        {
-            try
-            {
-                socket.EndSend(ar);
-            }
-            catch (Exception ex)
-            {
-                Debug.LogError(ex);
-            }
-        }
-
-        public void Disconnect()
-        {
-            Debug.Log("Client " + id + " has disconnected");
-            socket.Close();
-            server.clients[id] = null;
+    internal void RemoveClient(int id) {
+        lock(clients) {
+            clients[id] = null;
         }
     }
 
-    public void DisconnectClients()
+    public void Disconnect()
     {
-        foreach (var client in clients.Values)
-        {
-            client.Disconnect();
+        lock(clients) {
+            var clientConnections = clients.Values.ToList();
+            foreach (var client in clientConnections)
+                client.Disconnect();
+        }
+        if (serverSocket != null) {// && serverSocket.Connected) {
+            //serverSocket.Shutdown(SocketShutdown.Both);
+            serverSocket.Close();
+            serverSocket = null;
         }
     }
 
     public void SendToClient(byte[] data, int client)
     {
-        clients[client].Send(data);
-    }
-
-    public virtual void RouteMessageToFunction(byte[] receivedData, int id)
-    {
-        BlockPos pos;
-
-        switch (receivedData[0])
-        {
-            case VmNetworking.SendBlockChange:
-                pos = BlockPos.FromBytes(receivedData, 1);
-                ReceiveChange(pos, Block.New(BitConverter.ToUInt16(receivedData, 13), world), id);
-                break;
-            case VmNetworking.RequestChunkData:
-                pos = BlockPos.FromBytes(receivedData, 1);
-                RequestChunk(pos, id);
-                break;
+        lock (clients) {
+            ClientConnection clientConnection = clients[client];
+            if ( clientConnection != null )
+                clientConnection.Send(data);
         }
     }
-
 
     public void RequestChunk(BlockPos pos, int id)
     {
+        Chunk chunk = null;
+        if (world == null) {
+            Debug.LogError("VmServer.RequestChunk (" + Thread.CurrentThread.ManagedThreadId + "): "
+                + " world not set (" + pos + ", " + id + ")");
+        } else
+            chunk = world.chunks.Get(pos);
+        byte[] data;
         //for now return an empty chunk if it isn't yet loaded
         // Todo: load the chunk then send it to the player
-        if (world.chunks.Get(pos) == null)
-        {
-            Debug.LogError("Could not find chunk for " + pos);
-            SendChunk(pos, new byte[16384], id);
-        }
-        else
-        {
-            byte[] data = world.chunks.Get(pos).blocks.ToBytes();
-            SendChunk(pos, data, id);
-        }
+        if (chunk == null) {
+            Debug.LogError("VmServer.RequestChunk (" + Thread.CurrentThread.ManagedThreadId + "): "
+                + "Could not find chunk for " + pos);
+            data = ChunkBlocks.EmptyBytes;
+        } else
+            data = chunk.blocks.ToBytes();
+        if ( debugServer )
+            Debug.Log("VmServer.RequestChunk (" + Thread.CurrentThread.ManagedThreadId + "): " + id
+                + " " + pos);
+
+        SendChunk(pos, data, id);
     }
+
+    public const int headerSize = 13, leaderSize = headerSize + 8;
 
     protected void SendChunk(BlockPos pos, byte[] chunkData, int id)
     {
         int chunkDataIndex = 0;
-        while (chunkDataIndex < chunkData.Length)
-        {
-            byte[] message = new byte[1024];
+        while (chunkDataIndex < chunkData.Length) {
+            byte[] message = new byte[VmNetworking.bufferLength];
             message[0] = VmNetworking.transmitChunkData;
             pos.ToBytes().CopyTo(message, 1);
-            BitConverter.GetBytes(chunkData.Length).CopyTo(message, 13);
+            BitConverter.GetBytes(chunkDataIndex).CopyTo(message, headerSize);
+            BitConverter.GetBytes(chunkData.Length).CopyTo(message, headerSize + 4);
 
-            for (int i = 17; i < message.Length; i++)
-            {
+            if ( debugServer )
+                Debug.Log("VmServer.SendChunk (" + Thread.CurrentThread.ManagedThreadId + "): " + pos
+                    + ", chunkDataIndex=" + chunkDataIndex
+                    + ", chunkData.Length=" + chunkData.Length
+                    + ", buffer=" + message.Length);
+
+            for (int i = leaderSize; i < message.Length; i++) {
                 message[i] = chunkData[chunkDataIndex];
                 chunkDataIndex++;
 
-                if (chunkDataIndex >= chunkData.Length)
-                {
+                if (chunkDataIndex >= chunkData.Length) {
                     break;
                 }
             }
@@ -196,29 +169,143 @@ public class VmServer {
 
     public void BroadcastChange(BlockPos pos, Block block, int excludedUser)
     {
-        if (clients.Count == 0)
-        {
-            return;
-        }
+        lock(clients) {
+            if (clients.Count == 0) {
+                return;
+            }
 
-        byte[] data = new byte[15];
+            byte[] data = new byte[15];
 
-        data[0] = VmNetworking.SendBlockChange;
-        pos.ToBytes().CopyTo(data, 1);
-        BitConverter.GetBytes(block.type).CopyTo(data, 13);
+            data[0] = VmNetworking.SendBlockChange;
+            pos.ToBytes().CopyTo(data, 1);
+            BitConverter.GetBytes(block.type).CopyTo(data, 13);
 
-        foreach (var client in clients.Values)
-        {
-            if (excludedUser == -1 || client.id != excludedUser)
-            {
-                client.Send(data);
+            foreach (var client in clients.Values) {
+                if (excludedUser == -1 || client.ID != excludedUser) {
+                    client.Send(data);
+                }
             }
         }
     }
 
-    public void ReceiveChange(BlockPos pos, Block block, int id)
+    public void ReceiveChange(BlockPos pos, int type, int id)
     {
+        Block block = Block.New(type, world);
         world.blocks.Set(pos, block, updateChunk: true, setBlockModified: true);
         BroadcastChange(pos, block, id);
+    }
+}
+
+internal class ClientConnection : VmSocketState.IMessageHandler {
+
+    private int id;
+    private Socket socket;
+    private VmServer server;
+
+    private bool debugClientConnection = false;
+
+    public int ID { get { return id; } }
+
+    public ClientConnection(int id, Socket socket, VmServer server) {
+        this.id = id;
+        this.socket = socket;
+        this.server = server;
+        if ( debugClientConnection )
+            Debug.Log("ClientConnection.ClientConnection (" + Thread.CurrentThread.ManagedThreadId + "): "
+                + "Client " + id + " has connected");
+
+        VmSocketState socketState = new VmSocketState(this);
+        socket.BeginReceive(socketState.buffer, 0, VmNetworking.bufferLength, SocketFlags.None, new AsyncCallback(OnReceiveFromClient), socketState);
+    }
+
+    private void OnReceiveFromClient(IAsyncResult ar) {
+        try {
+            if (socket == null || !socket.Connected) {
+                Debug.Log("ClientConnection.OnReceiveFromClient (" + Thread.CurrentThread.ManagedThreadId + "): "
+                    + "client message rejected because connection was shutdown or not started");
+                return;
+            }
+            int received = socket.EndReceive(ar);
+
+            if (received == 0) {
+                Disconnect();
+                return;
+            }
+
+            if (debugClientConnection)
+                Debug.Log("ClientConnection.OnReceiveFromClient (" + Thread.CurrentThread.ManagedThreadId + "): " + id);
+
+            VmSocketState socketState = ar.AsyncState as VmSocketState;
+            socketState.Receive(received, 0);
+            if (socket != null && socket.Connected) {// Should be able to use a mutex but unity doesn't seem to like it
+                socket.BeginReceive(socketState.buffer, 0, VmNetworking.bufferLength, SocketFlags.None, new AsyncCallback(OnReceiveFromClient), socketState);
+            }
+        } catch (Exception ex) {
+            Debug.LogError(ex);
+        }
+    }
+
+    public int GetExpectedSize(byte type) {
+        switch (type) {
+            case VmNetworking.SendBlockChange:
+                return 17;
+            case VmNetworking.RequestChunkData:
+                return 13;
+            default:
+                return 0;
+        }
+    }
+
+    public void HandleMessage(byte[] receivedData) {
+        BlockPos pos;
+
+        switch (receivedData[0]) {
+            case VmNetworking.SendBlockChange:
+                pos = BlockPos.FromBytes(receivedData, 1);
+                int type = BitConverter.ToUInt16(receivedData, 13);
+                server.ReceiveChange(pos, type, id);
+                break;
+            case VmNetworking.RequestChunkData:
+                pos = BlockPos.FromBytes(receivedData, 1);
+
+                if (debugClientConnection)
+                    Debug.Log("ClientConnection.HandleMessage (" + Thread.CurrentThread.ManagedThreadId + "): " + id
+                        + " " + pos);
+
+                server.RequestChunk(pos, id);
+                break;
+        }
+    }
+
+    public void Send(byte[] buffer) {
+        try {
+            socket.BeginSend(buffer, 0, buffer.Length, SocketFlags.None, new AsyncCallback(OnSend), socket);
+        } catch (Exception ex) {
+            Debug.LogError(ex);
+        }
+    }
+
+    private void OnSend(IAsyncResult ar) {
+        try {
+            socket.EndSend(ar);
+        } catch (Exception ex) {
+            Debug.LogError(ex);
+        }
+    }
+
+    public void Disconnect() {
+        if (debugClientConnection)
+            Debug.Log("ClientConnection.Disconnect (" + Thread.CurrentThread.ManagedThreadId + "): "
+                + "Client " + id + " has disconnected");
+        try {
+            if (socket != null) {// && socket.Connected) {
+                //socket.Shutdown(SocketShutdown.Both);
+                socket.Close();
+                socket = null;
+            }
+        } catch (Exception ex) {
+            Debug.LogError(ex);
+        }
+        server.RemoveClient(id);
     }
 }

--- a/Assets/Voxelmetric/Code/World/VmSocketState.cs
+++ b/Assets/Voxelmetric/Code/World/VmSocketState.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using UnityEngine;
+
+/// <summary>
+/// Handles recovery of information streamed over TCP back into messages of known size
+/// </summary>
+public class VmSocketState {
+
+    public interface IMessageHandler {
+        int GetExpectedSize(byte messageType);
+        void HandleMessage(byte[] message);
+    }
+
+    public byte[] buffer = new byte[VmNetworking.bufferLength];
+
+    private byte[] message = new byte[VmNetworking.bufferLength];
+    private int messageOffset = 0;
+    private int expectedSize = 0;
+    private bool tmpExpectedSize;
+
+    private IMessageHandler messageHandler;
+
+    public VmSocketState(IMessageHandler messageHandler) {
+        this.messageHandler = messageHandler;
+        ResetMessage();
+    }
+
+    public void Receive(int received, int bufferOffset) {
+        if (messageOffset == 0) {
+            expectedSize = messageHandler.GetExpectedSize(buffer[bufferOffset]);
+            if (expectedSize < 0) {
+                expectedSize = -expectedSize;
+                tmpExpectedSize = true;
+            }
+        }
+
+        int messageEnd = messageOffset + received;
+        int messageExtra = 0;
+        if (messageEnd > expectedSize) {
+            messageExtra = messageEnd - expectedSize;
+            messageEnd = expectedSize;
+        }
+        int toCopy = received - messageExtra;
+        Array.Copy(buffer, bufferOffset, message, messageOffset, toCopy);
+        messageOffset += toCopy;
+        if (messageOffset == expectedSize) {
+            if (tmpExpectedSize) {
+                //TODO So that small chunks don't need 1025 bytes to be sent...
+            }
+            // Message complete -- dispatch it!
+            messageHandler.HandleMessage(message);
+            ResetMessage(); // get ready for the next message
+        }
+        if (messageExtra > 0) {
+            bufferOffset += toCopy;
+            Receive(messageExtra, bufferOffset);
+        }
+    }
+
+    private void ResetMessage() {
+        messageOffset = 0;
+        expectedSize = 0;
+    }
+}

--- a/Assets/Voxelmetric/Code/World/VmSocketState.cs.meta
+++ b/Assets/Voxelmetric/Code/World/VmSocketState.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d6620d76fd02a1b47bef21aeb5efb7d5
+timeCreated: 1459579260
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Voxelmetric/Code/World/World.cs
+++ b/Assets/Voxelmetric/Code/World/World.cs
@@ -23,18 +23,17 @@ public class World : MonoBehaviour {
     [HideInInspector]
     public byte worldIndex;
 
-    void Start()
-    {
-        config = new ConfigLoader<WorldConfig>(new string[] { "Worlds" }).GetConfig(worldConfig);
-
-        networking.StartConnections(this);
+    public World() {
         chunks = new WorldChunks(this);
         blocks = new WorldBlocks(this);
+    }
 
-        worldIndex = Voxelmetric.resources.AddWorld(this);
+    void Start()
+    {
+        Configure();
 
-        textureIndex = Voxelmetric.resources.GetOrLoadTextureIndex(this);
-        blockIndex = Voxelmetric.resources.GetOrLoadBlockIndex(this);
+        networking.StartConnections(this);
+
         terrainGen = new TerrainGen(this, config.layerFolder);
 
         gameObject.GetComponent<Renderer>().material.mainTexture = textureIndex.atlas;
@@ -50,17 +49,14 @@ public class World : MonoBehaviour {
     void OnApplicationQuit()
     {
         chunksLoop.isPlaying = false;
-
-        if (networking.isServer)
-        {
-            if (networking.allowConnections)
-            {
-                networking.server.DisconnectClients();
-            }
-        }
-        else
-        {
-            networking.client.Disconnect();
-        }
+        networking.EndConnections();
     }
+
+    public void Configure() {
+        config = new ConfigLoader<WorldConfig>(new string[] { "Worlds" }).GetConfig(worldConfig);
+        worldIndex = Voxelmetric.resources.AddWorld(this);
+        textureIndex = Voxelmetric.resources.GetOrLoadTextureIndex(this);
+        blockIndex = Voxelmetric.resources.GetOrLoadBlockIndex(this);
+    }
+
 }

--- a/Assets/Voxelmetric/Code/World/WorldChunks.cs
+++ b/Assets/Voxelmetric/Code/World/WorldChunks.cs
@@ -35,6 +35,11 @@ public class WorldChunks {
         return containerChunk;
     }
 
+    public void Set(BlockPos pos, Chunk chunk) {
+        pos = pos.ContainingChunkCoordinates();
+        chunks[pos] = chunk;
+    }
+
     public void Remove(BlockPos pos)
     {
         chunks.Remove(pos);

--- a/Assets/Voxelmetric/Tests.meta
+++ b/Assets/Voxelmetric/Tests.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: daa9d433314a9e640a2c4b9e8736045b
+folderAsset: yes
+timeCreated: 1458099638
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Voxelmetric/Tests/Editor.meta
+++ b/Assets/Voxelmetric/Tests/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d84a34193f758954eb5aadf5ea39102e
+folderAsset: yes
+timeCreated: 1458099644
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Voxelmetric/Tests/Editor/BlockPosTest.cs
+++ b/Assets/Voxelmetric/Tests/Editor/BlockPosTest.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using UnityEngine;
+
+public class BlockPosTest {
+    [Test]
+    public void ContainingChunkCoordinatesTest() {
+        AssertContainingChunkCoordinates(new BlockPos(0, 0, 0));
+        AssertContainingChunkCoordinates(new BlockPos(-1, -1, -1));
+        AssertContainingChunkCoordinates(new BlockPos(-15, -11, -4));
+        AssertContainingChunkCoordinates(new BlockPos(-35, -21, -127));
+        AssertContainingChunkCoordinates(new BlockPos(15, 11, 4));
+        AssertContainingChunkCoordinates(new BlockPos(16, 11, 4));
+        AssertContainingChunkCoordinates(new BlockPos(35, 21, 127));
+    }
+
+    private static void AssertContainingChunkCoordinates(BlockPos pos) {
+        Assert.AreEqual(ExpContainingChunkCoordinates(pos), pos.ContainingChunkCoordinates(), pos.ToString());
+    }
+
+    //returns the position of the chunk containing this block
+    private static BlockPos ExpContainingChunkCoordinates(BlockPos pos) {
+        int chunkSize = Config.Env.ChunkSize;
+
+        int cx = Mathf.FloorToInt(pos.x / (float)chunkSize) * chunkSize;
+        int cy = Mathf.FloorToInt(pos.y / (float)chunkSize) * chunkSize;
+        int cz = Mathf.FloorToInt(pos.z / (float)chunkSize) * chunkSize;
+
+        return new BlockPos(cx, cy, cz);
+    }
+}

--- a/Assets/Voxelmetric/Tests/Editor/BlockPosTest.cs.meta
+++ b/Assets/Voxelmetric/Tests/Editor/BlockPosTest.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 755a4c9ba18c1414f8fd762af5816e48
+timeCreated: 1459032920
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Voxelmetric/Tests/Editor/TestUtils.cs
+++ b/Assets/Voxelmetric/Tests/Editor/TestUtils.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using UnityEngine;
+
+/// <summary>
+/// Testing utilities
+/// </summary>
+public class TestUtils {
+
+    /// <summary>
+    /// Create a default world object for testing
+    /// </summary>
+    /// <returns></returns>
+    public static World CreateWorldDefault() {
+        World world = CreateWorldObject();
+        world.worldConfig = "default";
+        world.worldName = "defaultTest";
+        return world;
+    }
+
+    private static World CreateWorldObject() {
+        var gameObject = new GameObject();
+        return gameObject.AddComponent<World>();
+    }
+
+    public class AutoDictionary<TKey, TValue> : Dictionary<TKey, TValue> {
+
+        public new TValue this[TKey key] {
+            get {
+                TValue value;
+                if (!TryGetValue(key, out value)) {
+                    if (value == null)
+                        value = Activator.CreateInstance<TValue>();
+                    base[key] = value;
+                }
+                return value;
+            }
+            set {
+                base[key] = value;
+            }
+        }
+    }
+
+    public static void DebugBlockCounts(string name, Dictionary<string, int> blockCounts) {
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine(name + " block counts");
+        foreach (var pair in blockCounts) {
+            sb.AppendLine(pair.Key + "=" + pair.Value);
+        }
+        Debug.Log(sb.ToString());
+    }
+
+    public static void DebugChunks(string name, ICollection<Chunk> chunks) {
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine(name + " chunks");
+        foreach (var chunk in chunks) {
+            sb.AppendLine(chunk.ToString());
+        }
+        Debug.Log(sb.ToString());
+    }
+
+    public static readonly BlockPosEnumerable LocalPosns = new BlockPosEnumerable(BlockPos.one * Config.Env.ChunkSize);
+
+    public static AutoDictionary<string, int> FindWorldBlockCounts(World world) {
+        var worldBlockCounts = new AutoDictionary<string, int>();
+        foreach (var chunk in world.chunks.chunkCollection) {
+            var chunkBlockCounts = FindChunkBlockCounts(chunk);
+            foreach (var pair in chunkBlockCounts) {
+                worldBlockCounts[pair.Key] += pair.Value;
+            }
+        }
+        return worldBlockCounts;
+    }
+
+    public static AutoDictionary<string, int> FindChunkBlockCounts(Chunk chunk) {
+        AutoDictionary<string, int> chunkBlockCounts = new AutoDictionary<string, int>();
+        foreach (BlockPos localPos in LocalPosns) {
+            Block block = chunk.blocks.LocalGet(localPos);
+            chunkBlockCounts[block.name]++;
+        }
+        return chunkBlockCounts;
+    }
+
+    public static void SetChunkBlocksRandom(Chunk chunk, System.Random rand) {
+        World world = chunk.world;
+
+        const int blockTypes = 2;
+        for (int type = 0; type < blockTypes; ++type) {
+            var config = world.blockIndex.GetConfig(type);
+            Assert.IsNotNull(config, "config");
+            Assert.IsNotNull(config.blockClass, "config.blockClass");
+        }
+
+        Block[] rndBlocks = new Block[blockTypes];
+        for (int type = 0; type < blockTypes; ++type) {
+            Block block = new Block(type);
+            block.worldIndex = world.worldIndex;
+            rndBlocks[type] = block;
+        }
+
+        foreach (BlockPos localPos in LocalPosns)
+            chunk.blocks.LocalSet(localPos, rndBlocks[rand.Next(2)]);
+    }
+
+    public static void SetChunkBlocks(Chunk chunk, int type) {
+        World world = chunk.world;
+
+        var config = world.blockIndex.GetConfig(type);
+        Assert.IsNotNull(config, "config");
+        Assert.IsNotNull(config.blockClass, "config.blockClass");
+
+        Block block = new Block(type);
+        block.worldIndex = world.worldIndex;
+
+        foreach (BlockPos localPos in LocalPosns)
+            chunk.blocks.LocalSet(localPos, block);
+    }
+
+    public static void AssertEqualContents(Chunk expected, Chunk actual, string message) {
+        foreach (BlockPos localPos in LocalPosns) {
+            Block expBlock = expected.blocks.LocalGet(localPos);
+            Block actBlock = actual.blocks.LocalGet(localPos);
+            Assert.AreEqual(expBlock.type, actBlock.type, message + " type at " + localPos);
+        }
+    }
+
+}

--- a/Assets/Voxelmetric/Tests/Editor/TestUtils.cs.meta
+++ b/Assets/Voxelmetric/Tests/Editor/TestUtils.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 003b236915e03aa4e9a4b267cba35ddc
+timeCreated: 1459736823
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Voxelmetric/Tests/Editor/VmNetworkingTest.cs
+++ b/Assets/Voxelmetric/Tests/Editor/VmNetworkingTest.cs
@@ -1,0 +1,135 @@
+﻿using UnityEngine;
+using UnityEditor;
+using NUnit.Framework;
+using System.Net;
+using System.Threading;
+using System.Collections.Generic;
+using System;
+
+public class VmNetworkingTest {
+
+    [Test]
+    public void SerializationTest()
+    {
+        bool debug = false;
+
+        World world = TestUtils.CreateWorldDefault();
+        world.Configure();
+
+        BlockPos chunkPos = new BlockPos(0, 0, 0);
+        Chunk fromChunk = new Chunk(world, chunkPos);
+        TestUtils.SetChunkBlocksRandom(fromChunk, new System.Random(444));
+        
+        if (debug) TestUtils.DebugBlockCounts("fromChunk", TestUtils.FindChunkBlockCounts(fromChunk));
+
+        byte[] chunkData = fromChunk.blocks.ToBytes();
+        Chunk toChunk = new Chunk(world, chunkPos);
+
+        const int headerSize = VmServer.headerSize;
+        const int leaderSize = VmServer.leaderSize;
+
+        int chunkDataIndex = 0;
+        while (chunkDataIndex < chunkData.Length) {
+            byte[] message = new byte[1024];
+            message[0] = VmNetworking.transmitChunkData;
+            chunkPos.ToBytes().CopyTo(message, 1);
+            BitConverter.GetBytes(chunkDataIndex).CopyTo(message, headerSize);
+            BitConverter.GetBytes(chunkData.Length).CopyTo(message, headerSize + 4);
+
+            for (int i = leaderSize; i < message.Length; i++) {
+                message[i] = chunkData[chunkDataIndex];
+                chunkDataIndex++;
+
+                if (chunkDataIndex >= chunkData.Length) {
+                    break;
+                }
+            }
+
+            toChunk.blocks.ReceiveChunkData(message);
+        }
+
+        // Check that toChunk has the same blocks as fromChunk
+        if (debug) TestUtils.DebugBlockCounts("toChunk", TestUtils.FindChunkBlockCounts(toChunk));
+        TestUtils.AssertEqualContents(fromChunk, toChunk, "serialized chunk");
+    }
+
+    [Test]
+    public void TCPTest() {
+        bool debug = false;
+
+        var chunkSizePos = BlockPos.one * Config.Env.ChunkSize;
+        BlockPosEnumerable chunkPosns = new BlockPosEnumerable(-chunkSizePos, chunkSizePos, chunkSizePos, true);
+
+        VmServer server = null;
+        VmClient client = null;
+
+        try {
+            // Create two worlds, one as a server and another as a client to that server
+            World serverWorld = TestUtils.CreateWorldDefault();
+            serverWorld.Configure();
+            server = new VmServer(serverWorld);
+
+            Assert.AreEqual(0, server.ClientCount, "Initial client count");
+
+            World clientWorld = TestUtils.CreateWorldDefault();
+            clientWorld.Configure();
+            client = new VmClient(clientWorld, server.ServerIP);
+
+            // Wait a short while for the client and server to get done initializing
+            Thread.Sleep(100); // 100 ms should be plenty of time
+
+            Assert.AreEqual(1, server.ClientCount, "Connected client count");
+
+            // Setup a chunk with random blocks on the server
+            BlockPos chunkPos = new BlockPos(0, 0, 0);
+            Chunk serverChunk = new Chunk(serverWorld, chunkPos);
+            var rand = new System.Random(444);
+            TestUtils.SetChunkBlocksRandom(serverChunk, rand);
+            serverWorld.chunks.Set(chunkPos, serverChunk);
+
+            // Setup air chunks on the client
+            foreach (var pos in chunkPosns) {
+                Chunk chunk = new Chunk(clientWorld, pos);
+                TestUtils.SetChunkBlocks(chunk, Block.Air.type);
+                clientWorld.chunks.Set(pos, chunk);
+            }
+
+            // Have the client request the chunk
+            client.RequestChunk(chunkPos);
+
+            // Wait a short while for the request to be serviced
+            Thread.Sleep(100); // 100 ms should be plenty of time
+
+            // Test that the client chunk has been populated with the server data
+            Chunk clientChunk = clientWorld.chunks.Get(chunkPos);
+            TestUtils.AssertEqualContents(serverChunk, clientChunk, "clientChunk");
+
+            // Request 26 chunks around the first all at once
+            foreach (var pos in chunkPosns) {
+                if (pos == chunkPos)
+                    continue;
+                if (debug) TestUtils.DebugBlockCounts("before chunk " + pos, TestUtils.FindChunkBlockCounts(clientWorld.chunks.Get(pos)));
+                client.RequestChunk(pos);
+            }
+
+            // Wait a short while for the requests to be serviced
+            Thread.Sleep(1000); // 1 s should be plenty of time
+
+            // Expect all client chunks to have been set to the void that the server has
+            foreach (var pos in chunkPosns) {
+                if (pos == chunkPos)
+                    continue;
+                Chunk chunk = clientWorld.chunks.Get(pos);
+                if (debug) TestUtils.DebugBlockCounts("after chunk " + pos, TestUtils.FindChunkBlockCounts(chunk));
+                var chunkBlockCounts = TestUtils.FindChunkBlockCounts(chunk);
+                Assert.AreEqual(1, chunkBlockCounts.Count);
+                Assert.IsTrue(chunkBlockCounts.ContainsKey("void"), "expected void for " + pos);
+            }
+
+        } finally {
+            client.Disconnect();
+            server.Disconnect();
+        }
+    }
+
+}

--- a/Assets/Voxelmetric/Tests/Editor/VmNetworkingTest.cs.meta
+++ b/Assets/Voxelmetric/Tests/Editor/VmNetworkingTest.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 38a7bd8d469f53a459504bfc5efa738d
+timeCreated: 1459544806
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Voxelmetric/Tests/Editor/WorldTest.cs
+++ b/Assets/Voxelmetric/Tests/Editor/WorldTest.cs
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+using UnityEditor;
+using NUnit.Framework;
+
+public class WorldTest {
+
+    [Test]
+    public void ConstructionTest() {
+        World world = TestUtils.CreateWorldDefault();
+        Assert.IsNotNull(world.chunks, "world.chunks");
+        Assert.IsNotNull(world.blocks, "world.blocks");
+        world.Configure();
+        Assert.IsNotNull(world.config, "world.config");
+        Assert.IsNotNull(world.config.blockFolder, "world.config.blockFolder");
+        Assert.IsNotNull(world.textureIndex, "world.textureIndex");
+        Assert.IsNotNull(world.blockIndex, "world.blockIndex");
+    }
+
+}

--- a/Assets/Voxelmetric/Tests/Editor/WorldTest.cs.meta
+++ b/Assets/Voxelmetric/Tests/Editor/WorldTest.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ce2f7c03f3ec3f74590fc57642113ade
+timeCreated: 1459736850
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Profiling in unity showed that a lot of time was being spent doing 'default equals' during dictionary lookups -- particularly this appears to create quite a bit of garbage and cause the occaisional lag spike.

I found that the recommended course of action is the have the struct that is being used as a Dictionary key (BlockPos in this case) implements IEquatable.

This changeset makes BlockPos implement IEquatable and makes a couple of other performance changes:

Fix GetHashCode and Equals and use Equals to implement == and != operators

Speed up ContainingChunkCoordinates by using bitshifting, adding a unit test to compare to the old implementation.